### PR TITLE
Update Ooyala player version from Sandbox to Prod

### DIFF
--- a/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
+++ b/extensions/amp-ooyala-player/0.1/amp-ooyala-player.js
@@ -109,7 +109,7 @@ class AmpOoyalaPlayer extends AMP.BaseElement {
     const playerVersion = el.getAttribute('data-playerversion') || '';
     if (playerVersion.toLowerCase() == 'v4') {
       src =
-        'https://player.ooyala.com/static/v4/sandbox/amp_iframe/' +
+        'https://player.ooyala.com/static/v4/production/' +
         'skin-plugin/amp_iframe.html?pcode=' +
         encodeURIComponent(this.pCode_);
       const configUrl = el.getAttribute('data-config');


### PR DESCRIPTION
The Ooyala player iframe version currently used is at https://player.ooyala.com/static/v4/sandbox/amp_iframe/skin-plugin/amp_iframe.html which is using the player version 4.10.6

Our current production version is at v4.32.8. This update will solve some customer issues with analytics and provide them with a more recent and stable player


